### PR TITLE
Updates format of modlist.json to remove mod indexes

### DIFF
--- a/modlist.json
+++ b/modlist.json
@@ -1,5 +1,5 @@
-{
-  "0": {
+[
+  {
     "name": "/crew - Command",
     "author": "Aki",
     "tested_version": "n/a",
@@ -8,73 +8,73 @@
     "package": "AvorionCommands",
     "files": [
       {
-        "file_name":"crew.lua",
+        "file_name": "crew.lua",
         "url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/commands/crew.lua",
         "relative_path": "data/scripts/commands/"
       },
       {
-        "file_name":"crew.lua",
+        "file_name": "crew.lua",
         "url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/player/cmd/crew.lua",
         "relative_path": "data/scripts/player/cmd/"
       }
     ]
   },
-  "1": {
-		"name": "/price - Command",
-		"author": "Aki",
-		"tested_version": "n/a",
-		"url": "http://www.avorion.net/forum/index.php/topic,830.0.html",
-		"description": "Prints build cost of currently boarded ship. Usage: \n /price",
+  {
+    "name": "/price - Command",
+    "author": "Aki",
+    "tested_version": "n/a",
+    "url": "http://www.avorion.net/forum/index.php/topic,830.0.html",
+    "description": "Prints build cost of currently boarded ship. Usage: \n /price",
     "package": "AvorionCommands",
-		"files": [
-			{
-				"file_name":"price.lua",
-				"url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/commands/price.lua",
-				"relative_path": "data/scripts/commands/"
-			},
-			{
-				"file_name":"price.lua",
-				"url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/player/cmd/price.lua",
-				"relative_path": "data/scripts/player/cmd/"
-			}
-		]
-	},
-	"2": {
-		"name": "/inventory - Command",
-		"author": "Aki",
-		"tested_version": "n/a",
-		"url": "http://www.avorion.net/forum/index.php/topic,830.0.html",
-		"description": "Modifies inventory of a player. Usage: \n /inventory turret <type> [rarity] [material] [tech] [amount] \n /inventory upgrade <script> [rarity] [amount] \n /inventory available <turrets|upgrades|materials|rarities>",
-    "package": "AvorionCommands",
-		"files": [
-			{
-				"file_name": "inventory.lua",
-				"url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/commands/inventory.lua",
-				"relative_path": "data/scripts/commands/"
-			}
-		]
+    "files": [
+      {
+        "file_name": "price.lua",
+        "url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/commands/price.lua",
+        "relative_path": "data/scripts/commands/"
+      },
+      {
+        "file_name": "price.lua",
+        "url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/player/cmd/price.lua",
+        "relative_path": "data/scripts/player/cmd/"
+      }
+    ]
   },
-	"3": {
-		"name": "/sethome - Command",
-		"author": "Aki",
-		"tested_version": "n/a",
-		"url": "http://www.avorion.net/forum/index.php/topic,830.0.html",
-		"description": "Allows player to set current sector as home sector. Usage: /sethome",
+  {
+    "name": "/inventory - Command",
+    "author": "Aki",
+    "tested_version": "n/a",
+    "url": "http://www.avorion.net/forum/index.php/topic,830.0.html",
+    "description": "Modifies inventory of a player. Usage: \n /inventory turret <type> [rarity] [material] [tech] [amount] \n /inventory upgrade <script> [rarity] [amount] \n /inventory available <turrets|upgrades|materials|rarities>",
     "package": "AvorionCommands",
-		"files": [
-			{
-				"file_name":"sethome.lua",
-				"url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/commands/sethome.lua",
-				"relative_path": "data/scripts/commands/"
-			},
-			{
-				"file_name":"sethome.lua",
-				"url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/player/cmd/sethome.lua",
-				"relative_path": "data/scripts/player/cmd/"
-			}
-		]
+    "files": [
+      {
+        "file_name": "inventory.lua",
+        "url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/commands/inventory.lua",
+        "relative_path": "data/scripts/commands/"
+      }
+    ]
   },
-  "4": {
+  {
+    "name": "/sethome - Command",
+    "author": "Aki",
+    "tested_version": "n/a",
+    "url": "http://www.avorion.net/forum/index.php/topic,830.0.html",
+    "description": "Allows player to set current sector as home sector. Usage: /sethome",
+    "package": "AvorionCommands",
+    "files": [
+      {
+        "file_name": "sethome.lua",
+        "url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/commands/sethome.lua",
+        "relative_path": "data/scripts/commands/"
+      },
+      {
+        "file_name": "sethome.lua",
+        "url": "https://raw.githubusercontent.com/AvorionCommands/avorion-scripts/master/scripts/player/cmd/sethome.lua",
+        "relative_path": "data/scripts/player/cmd/"
+      }
+    ]
+  },
+  {
     "name": "Hightlight players in sector",
     "author": "TheSilentOracle",
     "tested_version": "1.0.1",
@@ -83,15 +83,15 @@
     "package": "0",
     "files": [
       {
-        "file_name":"server.lua",
+        "file_name": "server.lua",
         "url": "https://raw.githubusercontent.com/FederationOfEngineers/HighlitePlayers/master/scripts/server/server.lua",
         "relative_path": "data/scripts/commands/"
       },
       {
-        "file_name":"highlitePlayers.lua",
+        "file_name": "highlitePlayers.lua",
         "url": "https://raw.githubusercontent.com/FederationOfEngineers/HighlitePlayers/master/scripts/mods/player/highlitePlayers.lua",
         "relative_path": "data/scripts/player/cmd/"
       }
     ]
   }
-}
+]


### PR DESCRIPTION
### Goals

Convert the existing `modlist.json` which uses numeric key indexes to be an array of highly nested objects.  Using a JSON array should automatically create an indexed array of mods which we can then scrape the same way as before 🎉 


- [Example #5 on Sample JSON Data Formats](https://adobe.github.io/Spry/samples/data_region/JSONDataSetSample.html)